### PR TITLE
Add summarizer component

### DIFF
--- a/pages/summarizer/index.md
+++ b/pages/summarizer/index.md
@@ -1,0 +1,26 @@
+<script>
+    // Due to the location that Evidence builds the site, we need to hop up many directories to get to root
+    import Summarizer from "../../../../../src/lib/charts/analysis/Summarizer.svelte";
+</script>
+
+# Summarizer
+
+<Alert status=warning>
+This component requires the `formatTitle` and `formatValue` functions found in the `@evidence-dev/component-utilities` package. These are currently excluded from the component and as a result, some titles and values will be unformatted.
+</Alert>
+
+This component is a proof of concept for "analysis components" - components you can give a dataset to with minimal details, and have them complete aggregations and summaries for you.
+
+```sql categories
+select 'A' as category, 'West' as region, 120 as sales_usd
+union all
+select 'B' as category, 'East' as region, 2420 as sales_usd
+union all
+select 'C' as category, 'West' as region, 6443 as sales_usd
+union all
+select 'D' as category, 'East' as region, 5354 as sales_usd
+union all
+select 'E' as category, 'West' as region, 8459 as sales_usd
+```
+
+<Summarizer data={categories} value=sales_usd/>

--- a/src/lib/charts/analysis/Summarizer.svelte
+++ b/src/lib/charts/analysis/Summarizer.svelte
@@ -1,0 +1,149 @@
+<script context="module">
+    export const evidenceInclude = true;
+</script>
+
+<script>
+    import { DataTable } from '@evidence-dev/core-components';
+    import { Column } from '@evidence-dev/core-components';
+    import { BarChart } from '@evidence-dev/core-components';
+	// import {formatTitle} from '@evidence-dev/component-utilities';
+	// import {formatValue} from '@evidence-dev/component-utilities';
+    
+    export let data;
+    export let value;
+    export let otherThreshold = 0.03;
+
+    function getColumnNamesWithoutValue(arr, valueColumn) {
+  // Get the keys of the first object in the array
+  const keys = Object.keys(arr[0]);
+
+  // Filter out the value column from the keys
+  const columnNames = keys.filter(column => column !== valueColumn);
+
+  return columnNames;
+}
+
+function generateSumDataset(arr, valueColumn) {
+  // Get the column names excluding the value column
+  const columnNames = getColumnNamesWithoutValue(arr, valueColumn);
+
+  // Create an empty array for the dataset
+  const dataset = [];
+
+  // Loop through the column names
+  for (let i = 0; i < columnNames.length; i++) {
+    const columnName = columnNames[i];
+    const columnData = [];
+
+    // Group the sum of the value column by the current column
+    let totalValue = 0;
+    for (let j = 0; j < arr.length; j++) {
+      const row = arr[j];
+      const key = row[columnName];
+      const value = row[valueColumn];
+
+      if (!columnData.some(obj => obj[columnName] === key)) {
+        columnData.push({ column: columnName, [columnName]: key, [valueColumn]: 0 });
+      }
+
+      const obj = columnData.find(obj => obj[columnName] === key);
+      obj[valueColumn] += value;
+      totalValue += value;
+    }
+
+    // Calculate the percentage of the total for each row as a decimal number
+    for (let j = 0; j < columnData.length; j++) {
+      const obj = columnData[j];
+      const percentage = obj[valueColumn] / totalValue;
+      obj['pct_total_pct1'] = parseFloat(percentage.toFixed(4));
+    }
+
+    // Sort the columnData array in descending order based on the value of 'valueColumn'
+    columnData.sort((a, b) => b[valueColumn] - a[valueColumn]);
+
+    // Add the column data to the dataset array
+    dataset.push(columnData);
+  }
+
+  return dataset;
+}
+
+let summarizedData = generateSumDataset(data, value)
+
+
+function aggregateBelowThreshold(sumDataset, valueColumn, otherThreshold) {
+  // Loop through each dataset
+  for (let i = 0; i < sumDataset.length; i++) {
+    const dataset = sumDataset[i];
+    let otherItem = null;
+    let otherValue = 0;
+
+    // Loop through each item in the dataset
+    for (let j = 0; j < dataset.length; j++) {
+      const item = dataset[j];
+      const pct = item['pct_total_pct1'];
+
+      // Check if the percentage is below the threshold
+      if (pct < otherThreshold) {
+        // Aggregate the value to the "Other" item
+        if (!otherItem) {
+          otherItem = { ...item };
+          otherItem[otherItem.column] = 'Other';
+          otherValue += item[valueColumn];
+        } else {
+          otherValue += item[valueColumn];
+        }
+
+        // Remove the item from the dataset
+        dataset.splice(j, 1);
+        j--;
+      }
+    }
+
+    // Add the "Other" item if it exists
+    if (otherItem) {
+      otherItem[valueColumn] = otherValue;
+      dataset.push(otherItem);
+    }
+  }
+
+  return sumDataset;
+}
+
+function hasValuesBelowThreshold(dataset, otherThreshold) {
+  for (let i = 0; i < dataset.length; i++) {
+    const item = dataset[i];
+    const pct = item['pct_total_pct'];
+
+    if (pct < otherThreshold) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+aggregateBelowThreshold(summarizedData, value, otherThreshold)
+
+</script>
+
+<!-- <h2>{formatTitle(value)} Breakdown</h2> -->
+<h2>{value} Breakdown</h2>
+
+{#each summarizedData as column}
+
+<!-- <h3>{formatTitle(column[0].column)}</h3> -->
+<h3>{column[0].column}</h3>
+
+<BarChart data={column} x={column[0].column} y={value} swapXY=true/>
+
+<!-- <p class="text-sm ml-5">"Other" includes any categories below {formatValue(otherThreshold, '0%')} of total {value}, including x, y, z, and 14 more categories.</p> -->
+<p class="text-sm ml-5">"Other" includes any categories below {otherThreshold} of total {value}, including x, y, z, and 14 more categories.</p>
+
+<DataTable data={column}>
+    <Column id={column[0].column}/>
+    <Column id={value}/>
+    <Column id=pct_total_pct1/>
+</DataTable>
+
+{/each}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -7,3 +7,4 @@ export { default as GithubStarCount } from './ui/GithubStarCount.svelte';
 export { default as GoogleSheet } from './ui/GoogleSheet.svelte';
 export { default as Grid } from './ui/Grid.svelte';
 export { default as PDF } from './ui/PDF.svelte';
+export { default as Summarizer } from './charts/analysis/Summarizer.svelte';


### PR DESCRIPTION
Proof of concept for "analysis components" - components that will complete aggregations and summaries for you, as well as make choices about how to aggregate the data.

This first simple example accepts a dataset and a value column, then iterates through the table and aggregates by all other columns, producing a breakdown by each column in separate sections down the page.

It automatically aggregates categories below 3% of the total into an "Other" bucket, which is an interesting concept:
- This could be a configurable option for the end user (okay)
- Ideally, it would contain the logic required to make the best trade-off in terms of what to show, which wouldn't be a flat % rule. For example, if there were 30 categories at ~3%, lumping those together wouldn't work. It's likely some calculation relating to the distribution of the data, then a threshold level below which everything gets grouped.